### PR TITLE
Remove bare variables to fix Ansible 2 deprecation warnings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,12 +7,12 @@
 - name: Install the packages in Redhat derivates
   tags: git
   yum: name={{ item }} state=present
-  with_items: git_pkgs
+  with_items: '{{ git_pkgs }}'
   when: ansible_os_family == 'RedHat'
 
 - name: Install the packages in Debian derivates
   tags: git
   apt: name={{ item }} state=present update_cache=yes cache_valid_time=600
-  with_items: git_pkgs
+  with_items: '{{ git_pkgs }}'
   when: ansible_os_family == 'Debian'
 


### PR DESCRIPTION
Quote and use curly braces around the git_pkgs variable. This stops Ansible 2 complaining about use of bare variables, which have been deprecated.
